### PR TITLE
Add auth support

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,15 +1,19 @@
 const Koa = require('koa')
-const views = require('koa-views')
-const serveSass = require('koa.sass')
-const serveStatic = require('koa-static')
+const auth = require('koa-basic-auth');
 const bodyParser = require('koa-bodyparser')
 const mount = require('koa-mount')
+const serveSass = require('koa.sass')
+const serveStatic = require('koa-static')
 const utils = require('./controller/utils')
+const views = require('koa-views')
 
 const CONFIG = require('./config')
 const rootRoutes = require('./routes')
 
 const app = new Koa()
+
+
+app.use(mount('/create', auth({ name: 'saku', pass: CONFIG.password })));
 
 app.use(bodyParser())
 

--- a/config.js
+++ b/config.js
@@ -5,6 +5,7 @@ let CONFIG = {} //Make this global to use all over the application
 CONFIG.name           = process.env.NAME            || 'Default Name'
 CONFIG.email          = process.env.EMAIL           || 'mail@example.com'
 CONFIG.site           = process.env.SITE            || 'https://example.com'
+CONFIG.password       = process.env.PASSWORD        || 'saku'
 
 CONFIG.app            = process.env.APP             || 'dev'
 CONFIG.port           = process.env.PORT            || '3000'

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,6 +342,14 @@
         }
       }
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2406,6 +2414,14 @@
         "statuses": "^1.5.0",
         "type-is": "^1.6.16",
         "vary": "^1.1.2"
+      }
+    },
+    "koa-basic-auth": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/koa-basic-auth/-/koa-basic-auth-3.0.0.tgz",
+      "integrity": "sha512-8j4ddZCHrGB4tMC+3NYlO1ejAv/qCPouhymCexOIxzUhZ3wSaK1VdafohvUBSNbWD719lsi30n9TaW8QzyS3/A==",
+      "requires": {
+        "basic-auth": "^2.0.0"
       }
     },
     "koa-bodyparser": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "better-sqlite3": "^4.1.4",
     "dotenv": "^6.0.0",
     "koa": "^2.5.3",
+    "koa-basic-auth": "^3.0.0",
     "koa-bodyparser": "^4.2.1",
     "koa-mount": "^3.0.0",
     "koa-router": "^7.4.0",


### PR DESCRIPTION
This pull request adds support for basic auth using the koa-auth middleware and the mount plugin. The default password is set in  config.js and can be overridden by a password. The username is always saku. I wonder if all author commands should be prefixed with /a/ or some other namespace so the mount plugin could protect them all, for instance /a/create /a/edit/:id /a/delete/:id